### PR TITLE
Localize DB results in routes

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Chinese Medical Humanities Film",
   "main": "web.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node test/routes/test.js",
     "test.e2e": "npm run start & nightwatch",
     "start": "node web.js",
     "startmon": "nodemon web.js",
@@ -47,6 +47,7 @@
     "eslint": "^3.19.0",
     "nightwatch": "^0.9.16",
     "nodemon": "^1.11.0",
-    "selenium-download": "^2.0.10"
+    "selenium-download": "^2.0.10",
+    "tape": "^4.7.0"
   }
 }

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -19,7 +19,7 @@ const localize =  (locale, dbResultsObj) => {
       Object.assign({}, a, { [b.replace(translatableKeyReg, '')] : dbResultsObj[b], }), {});
 };
 
-module.exports = (locale, dbResults) => {
+const localizeResults = (locale, dbResults) => {
 
   // if currentLocale === defaultLocale, do nothing
   // english is default
@@ -33,3 +33,7 @@ module.exports = (locale, dbResults) => {
   return localize(locale, dbResults._doc);
 
 };
+
+module.exports = process.env === 'production'
+  ? localizeResults
+  : { localizeResults, localize, };

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -34,6 +34,4 @@ const localizeResults = (locale, dbResults) => {
 
 };
 
-module.exports = process.env === 'production'
-  ? localizeResults
-  : { localizeResults, localize, };
+module.exports = { localize, localizeResults, };

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -1,0 +1,24 @@
+module.exports = (locale, dbResults) => {
+
+  // if currentLocale === defaultLocale, do nothing
+  // english is default
+  if (locale === 'en') return dbResults;
+
+  // keynames in DB that contain translatable content follow pattern 'name___locale'
+  const separator = '___';
+  const translatableKeyReg = /\_{3}.+$/;
+
+  // gets array of translatable values from DB results
+  const translatableFields = Object.keys(dbResults._doc)
+    .filter(key => translatableKeyReg.test(key))
+    .map(filteredKey => filteredKey.replace(translatableKeyReg, ''));
+
+  // create new results object with relevant data only
+  return Object.keys(dbResults._doc)
+    .filter(key => {
+      const [ type, loc, ] = key.split(separator);
+      return translatableFields.indexOf(type) < 0 || loc === locale;
+    }) // change key name so that '___LOCALE' part is discarded
+    .reduce((a, b) =>
+      Object.assign({}, a, { [b.replace(translatableKeyReg, '')] : dbResults[b], }), {});
+};

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -4,16 +4,11 @@ const localize =  (locale, dbResultsObj) => {
   const separator = '___';
   const translatableKeyReg = /\_{3}.+$/;
 
-  // gets array of translatable values from DB results
-  const translatableFields = Object.keys(dbResultsObj)
-    .filter(key => translatableKeyReg.test(key))
-    .map(filteredKey => filteredKey.replace(translatableKeyReg, ''));
-
   // create new results object with relevant data only
   return Object.keys(dbResultsObj)
     .filter(key => {
-      const [ type, loc, ] = key.split(separator);
-      return translatableFields.indexOf(type) < 0 || loc === locale;
+      const loc = key.split(separator)[1];
+      return !loc || loc === locale;
     }) // change key name so that '___LOCALE' part is discarded
     .reduce((a, b) =>
       Object.assign({}, a, { [b.replace(translatableKeyReg, '')] : dbResultsObj[b], }), {});
@@ -30,7 +25,7 @@ const localizeResults = (locale, dbResults) => {
   }
 
   // if not array, pass in _doc object
-  return localize(locale, dbResults._doc);
+  return localize(locale, dbResults._doc || dbResults);
 
 };
 

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -1,3 +1,5 @@
+const { defaultLocale, } = require('../setup/locales.js');
+
 const localize =  (locale, dbResultsObj) => {
 
   // keynames in DB that contain translatable content follow pattern 'name___locale'
@@ -18,7 +20,7 @@ const localizeResults = (locale, dbResults) => {
 
   // if currentLocale === defaultLocale, do nothing
   // english is default
-  if (locale === 'en') return dbResults;
+  if (locale === defaultLocale) return dbResults;
 
   if (dbResults instanceof Array) {
     return dbResults.map(dbResult => localize(locale, dbResult));

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -30,6 +30,6 @@ module.exports = (locale, dbResults) => {
   }
 
   // if not array, pass in _doc object
-  return localize(dbResults._doc);
+  return localize(locale, dbResults._doc);
 
 };

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -1,24 +1,35 @@
-module.exports = (locale, dbResults) => {
-
-  // if currentLocale === defaultLocale, do nothing
-  // english is default
-  if (locale === 'en') return dbResults;
+const localize =  (locale, dbResultsObj) => {
 
   // keynames in DB that contain translatable content follow pattern 'name___locale'
   const separator = '___';
   const translatableKeyReg = /\_{3}.+$/;
 
   // gets array of translatable values from DB results
-  const translatableFields = Object.keys(dbResults)
+  const translatableFields = Object.keys(dbResultsObj)
     .filter(key => translatableKeyReg.test(key))
     .map(filteredKey => filteredKey.replace(translatableKeyReg, ''));
 
   // create new results object with relevant data only
-  return Object.keys(dbResults)
+  return Object.keys(dbResultsObj)
     .filter(key => {
       const [ type, loc, ] = key.split(separator);
       return translatableFields.indexOf(type) < 0 || loc === locale;
     }) // change key name so that '___LOCALE' part is discarded
     .reduce((a, b) =>
-      Object.assign({}, a, { [b.replace(translatableKeyReg, '')] : dbResults[b], }), {});
+      Object.assign({}, a, { [b.replace(translatableKeyReg, '')] : dbResultsObj[b], }), {});
+};
+
+module.exports = (locale, dbResults) => {
+
+  // if currentLocale === defaultLocale, do nothing
+  // english is default
+  if (locale === 'en') return dbResults;
+
+  if (dbResults instanceof Array) {
+    return dbResults.map(dbResult => localize(locale, dbResult));
+  }
+
+  // if not array, pass in _doc object
+  return localize(dbResults._doc);
+
 };

--- a/routes/helpers/localize_results.js
+++ b/routes/helpers/localize_results.js
@@ -9,12 +9,12 @@ module.exports = (locale, dbResults) => {
   const translatableKeyReg = /\_{3}.+$/;
 
   // gets array of translatable values from DB results
-  const translatableFields = Object.keys(dbResults._doc)
+  const translatableFields = Object.keys(dbResults)
     .filter(key => translatableKeyReg.test(key))
     .map(filteredKey => filteredKey.replace(translatableKeyReg, ''));
 
   // create new results object with relevant data only
-  return Object.keys(dbResults._doc)
+  return Object.keys(dbResults)
     .filter(key => {
       const [ type, loc, ] = key.split(separator);
       return translatableFields.indexOf(type) < 0 || loc === locale;

--- a/routes/setup/locales.js
+++ b/routes/setup/locales.js
@@ -1,0 +1,4 @@
+module.exports = {
+  locales: [ 'en', 'chn', ],
+  defaultLocale: 'en',
+};

--- a/test/routes/test.js
+++ b/test/routes/test.js
@@ -15,5 +15,8 @@ test('test localizeresults function', (t) => {
   const testObj = { key: 'value', name___en: 'nameEn', };
   t.deepEqual(localizeResults('en', testObj), testObj, 'same object returned when locale is EN');
   t.ok(localizeResults('fr', [ testObj, ]) instanceof Array, 'array returned if input is array');
+
+  const testObj2 = { key: 'value', name: 'name', name___de: 'nameDe', name___fr: 'nameFr', other___de: 'otherDe', };
+  t.deepEqual(localizeResults('fr', testObj2), { key: 'value', name: 'nameFr', }, 'irrelevant fields discarded');
   t.end();
 });

--- a/test/routes/test.js
+++ b/test/routes/test.js
@@ -1,6 +1,8 @@
 const test = require('tape');
 const { localize, localizeResults, } = require('../../routes/helpers/localize_results.js');
 
+const { defaultLocale, } = require('../../routes/setup/locales.js');
+
 test('test localize function', (t) => {
   t.deepEqual(localize('fr', {}), {}, 'returns an empty object if results object is empty');
   t.deepEqual(
@@ -13,7 +15,7 @@ test('test localize function', (t) => {
 
 test('test localizeresults function', (t) => {
   const testObj = { key: 'value', name___en: 'nameEn', };
-  t.deepEqual(localizeResults('en', testObj), testObj, 'same object returned when locale is EN');
+  t.deepEqual(localizeResults(defaultLocale, testObj), testObj, 'same object returned when locale is EN');
   t.ok(localizeResults('fr', [ testObj, ]) instanceof Array, 'array returned if input is array');
 
   const testObj2 = { key: 'value', name: 'name', name___de: 'nameDe', name___fr: 'nameFr', other___de: 'otherDe', };

--- a/test/routes/test.js
+++ b/test/routes/test.js
@@ -1,0 +1,7 @@
+const test = require('tape');
+const { localize, localizeResults, } = require('../../routes/helpers/localize_results.js');
+
+test('test localize results function', (t) => {
+  t.deepEqual(localize('fr', {}), {}, 'ok');
+  t.end();
+});

--- a/test/routes/test.js
+++ b/test/routes/test.js
@@ -1,7 +1,19 @@
 const test = require('tape');
 const { localize, localizeResults, } = require('../../routes/helpers/localize_results.js');
 
-test('test localize results function', (t) => {
-  t.deepEqual(localize('fr', {}), {}, 'ok');
+test('test localize function', (t) => {
+  t.deepEqual(localize('fr', {}), {}, 'returns an empty object if results object is empty');
+  t.deepEqual(
+    localize('es', { thing___es: 'thing', other: 'other thing', }),
+    { thing: 'thing', other: 'other thing', },
+    'locale removed from localised string'
+  );
+  t.end();
+});
+
+test('test localizeresults function', (t) => {
+  const testObj = { key: 'value', name___en: 'nameEn', };
+  t.deepEqual(localizeResults('en', testObj), testObj, 'same object returned when locale is EN');
+  t.ok(localizeResults('fr', [ testObj, ]) instanceof Array, 'array returned if input is array');
   t.end();
 });


### PR DESCRIPTION
creates helper function that takes mongo DB results and transforms them with localized data only

based on current locale, with English as default locale

logic for switching locales is coming in a separate PR, so this function is currently not being used anywhere

related #102