### PR TITLE
seperated out pinyin and hanzi in model/keystone 

### DIFF
--- a/models/movies.js
+++ b/models/movies.js
@@ -10,6 +10,7 @@ const Movie = new keystone.List('Movie', {
 Movie.add({
   name: { type: String, required: true, },
   name_chn: { type: String, label: 'Chinese title', }, // not a translatable field, because we need the name in English views
+  name_pinyin: { type: String, label: 'Chinese (Pinyin) title', }, // not a translatable field, because we need the name in English views
   director: { type: Types.Relationship, ref: 'Director', },
   year: { type: Number, },
   duration: { type: Number, label: 'duration (mins)', },

--- a/templates/mixins/movie-listing.pug
+++ b/templates/mixins/movie-listing.pug
@@ -19,7 +19,10 @@ mixin titleEn(title)
       
 mixin titleChn(movie)
   if movie.name_chn
-    h2.ttu.ma0.f6.f3-ns.pb2-ns.lh-copy.sans-serif.fw4=movie.name_chn
+    h2.ma0.f6.f3-ns.pb2-ns.lh-copy.sans-serif.fw4=movie.name_chn
+      span.ttu=movie.name_chn
+      if (movie.name_pinyin)
+        span.f5.f5-ns.normal.i  (#{movie.name_pinyin})
     
 mixin imgContainer(movie)
   .listingImg.flex-1-0-0.bt.b--light-gray.bw1(class=`bg-${primaryColor}`)

--- a/templates/views/movie_profile.pug
+++ b/templates/views/movie_profile.pug
@@ -27,7 +27,10 @@ block content
     
     if (movie.name_chn)
       h1.light-gray.ttu.f2.f1-ns.fw7.lh-copy.ma0.sans-serif=movie.name
-    h2.light-gray.ttu.f3.f3-ns.fw7.lh-title.ma0=movie.name_chn
+    h2.light-gray.f3.f3-ns.fw7.lh-title.ma0
+      span=movie.name_chn
+      if (movie.name_pinyin)
+        span.f5.f5-ns.normal.i  (#{movie.name_pinyin})
       
     h2.light-gray.f5.f4-ns.fw2.lh-title
       if movie.year


### PR DESCRIPTION
+ changed the view in movie_profile and movie_listing mixin (which is used throughout the site)

(still will need manually filling in on the actual site)

<img width="1082" alt="screen shot 2018-02-05 at 2 46 38 pm" src="https://user-images.githubusercontent.com/22657280/35810368-6e707c6e-0a83-11e8-94be-ec365e454d8f.png">
 #223